### PR TITLE
Bug fixes in odla layer

### DIFF
--- a/src/odla_layer.c
+++ b/src/odla_layer.c
@@ -79,10 +79,10 @@ odla_layer make_odla_layer(int batch, int h, int w, int c, int instance, const c
      * NOTE: Currently supports input of uint8 and output of int8
      **/
     l.batch = batch;
-    l.out_w = l.output_tensors[i].w;
-    l.out_h = l.output_tensors[i].h;
-    l.out_c = l.output_tensors[i].c;
-    l.outputs = l.output_tensors[i].size; // TODO: Fixit
+    l.out_w = l.output_tensors[0].w;
+    l.out_h = l.output_tensors[0].h;
+    l.out_c = l.output_tensors[0].c;
+    l.outputs = l.output_tensors[0].size; // TODO: Fixit
 
     l.output_i8 = calloc(l.outputs*batch, sizeof(int8_t));
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -558,9 +558,6 @@ odla_layer parse_odla(list *options, size_params params)
     const char *loadable = option_find_str(options, "loadable", "");
 
     odla_layer layer = make_odla_layer(params.batch, params.w, params.h, params.c, instance, loadable);
-    layer.w = layer.out_w = params.w;
-    layer.h = layer.out_h = params.h;
-    layer.c = layer.out_c = params.c;
     return layer;
 }
 


### PR DESCRIPTION
[1] Avoid out of index access to set output dimensions and size info
[2] Fixes bug that resets output dimensions of odla layer.

Signed-off-by: arvind <am@nvidia.com>