### PR TITLE
darknet: Update Upsample_dla to use int8 input and output

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -666,7 +666,6 @@ layer parse_upsample_dla(list *options, size_params params, network *net)
 
     int stride = option_find_int(options, "stride",2);
     layer l = make_upsample_dla_layer(params.batch, params.w, params.h, params.c, stride);
-    l.scale = option_find_float_quiet(options, "scale", 1);
     return l;
 }
 

--- a/src/upsample_dla_layer.c
+++ b/src/upsample_dla_layer.c
@@ -46,7 +46,7 @@ void *cubecpy(void *dst, const void *src){
     return dst;
 }
 
-void upsample_dla(float *in, int w, int h, int c, int batch, int stride, int forward, float scale, float *out)
+void upsample_dla(int8_t *in, int w, int h, int c, int batch, int stride, int forward, int8_t *out)
 {
     int i, j, k, b;
 
@@ -65,10 +65,9 @@ void upsample_dla(float *in, int w, int h, int c, int batch, int stride, int for
 
 void forward_upsample_dla_layer(const layer l, network net)
 {
-    fill_cpu(l.outputs*l.batch, 0, l.output, 1);
     if(l.reverse){
-        upsample_dla(l.output, l.out_w, l.out_h, l.c, l.batch, l.stride, 0, l.scale, net.input);
+        upsample_dla(l.output_i8, l.out_w, l.out_h, l.c, l.batch, l.stride, 0, net.input_i8);
     }else{
-        upsample_dla(net.input, l.w, l.h, l.c, l.batch, l.stride, 1, l.scale, l.output);
+        upsample_dla(net.input_i8, l.w, l.h, l.c, l.batch, l.stride, 1, l.output_i8);
     }
 }


### PR DESCRIPTION
Remove scale parameter and take unput/output in int8 format

Signed-off-by: Sharif Inamdar <isharif@nvidia.com>