### PR TITLE
Optimize memory access.

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -137,6 +137,8 @@ typedef struct {
     int instance;
     char *loadable;
     int input_tensor;
+    int from_odla_layer;
+    int from_odla_tensor;
 } odla_params;
 
 typedef struct{
@@ -156,6 +158,7 @@ typedef struct{
     int size;
     float *data;
     void *buffer;
+    void *hMem;
 } tensor;
 
 struct network;

--- a/src/odla_layer.c
+++ b/src/odla_layer.c
@@ -9,8 +9,9 @@ extern void *odla_get_output(void *runtime, int index);
 extern void odla_execute(void *runtime, int instance);
 extern int odla_num_input(void *runtime);
 extern int odla_num_output(void *runtime);
-extern void odla_alloc_input_tensor(void *runtime, void *buffer, int index);
-extern void odla_alloc_output_tensor(void *runtime, void *buffer, int index);
+extern void odla_alloc_input_tensor(void *runtime, void *buffer, int index, void **memory_handle);
+extern void odla_bind_input_tensor(void *runtime, int index, void *memory_handle);
+extern void odla_alloc_output_tensor(void *runtime, void *buffer, int index, void **memory_handle);
 extern int odla_input_channel(void *runtime, int index);
 extern int odla_input_width(void *runtime, int index);
 extern int odla_input_height(void *runtime, int index);
@@ -54,7 +55,7 @@ static void odla_dump_data(const char *filename, int8_t *data, int w, int h, int
 }
 
 odla_layer make_odla_layer(int batch, int h, int w, int c,
-                            odla_params params)
+                            odla_params params, network *net)
 {
     int i = 0;
 
@@ -70,6 +71,13 @@ odla_layer make_odla_layer(int batch, int h, int w, int c,
     l.dla_params = params;
     l.input_tensor = params.input_tensor;
 
+    layer *prev_odla_layer = NULL;
+    tensor *prev_odla_tensor = NULL;
+    if (params.from_odla_layer != -1) {
+        prev_odla_layer = &net->layers[params.from_odla_layer];
+        prev_odla_tensor = &prev_odla_layer->output_tensors[params.from_odla_tensor];
+    }
+
     //create runtime instance
     l.odla_runtime = odla_create_runtime();
 
@@ -80,13 +88,24 @@ odla_layer make_odla_layer(int batch, int h, int w, int c,
     l.num_input = odla_num_input(l.odla_runtime);
     l.input_tensors = calloc(l.num_input, sizeof(tensor));
     for (i = 0; i < l.num_input; i++) {
-        l.input_tensors[i].w = odla_input_width(l.odla_runtime, i);
-        l.input_tensors[i].h = odla_input_height(l.odla_runtime, i);
-        l.input_tensors[i].c = odla_input_channel(l.odla_runtime, i);
+        if (prev_odla_layer == NULL) {
+            l.input_tensors[i].w = odla_input_width(l.odla_runtime, i);
+            l.input_tensors[i].h = odla_input_height(l.odla_runtime, i);
+            l.input_tensors[i].c = odla_input_channel(l.odla_runtime, i);
 
-        l.input_tensors[i].size = odla_input_size(l.odla_runtime, i);
-        l.input_tensors[i].buffer = NULL;
-        odla_alloc_input_tensor(l.odla_runtime, &l.input_tensors[i].buffer, i);
+            l.input_tensors[i].size = odla_input_size(l.odla_runtime, i);
+            l.input_tensors[i].buffer = NULL;
+            odla_alloc_input_tensor(l.odla_runtime, &l.input_tensors[i].buffer, i, &l.input_tensors[i].hMem);
+        }
+        else {
+            if (prev_odla_tensor != NULL) {
+                l.input_tensors[i] = *prev_odla_tensor;
+                odla_bind_input_tensor(l.odla_runtime, i, l.input_tensors[i].hMem);
+            }
+            else {
+                fprintf(stderr, "Invalid from_odla_tensor!\n");
+            }
+        }
     }
 
     //setup output tensors
@@ -99,7 +118,7 @@ odla_layer make_odla_layer(int batch, int h, int w, int c,
 
         l.output_tensors[i].size = odla_output_size(l.odla_runtime, i);
         fprintf(stderr, "odla          tensor %d %4d x%4d x%4d   ->  %4d x%4d x%4d\n", i, w, h, c, l.output_tensors[i].w, l.output_tensors[i].h, l.output_tensors[i].c);
-        odla_alloc_output_tensor(l.odla_runtime, &l.output_tensors[i].buffer, i);
+        odla_alloc_output_tensor(l.odla_runtime, &l.output_tensors[i].buffer, i, &l.output_tensors[i].hMem);
     }
 
     l.batch = batch;
@@ -127,7 +146,10 @@ void forward_odla_layer(const layer l, network net)
     //it is assumed that another input is from upsample layer which will
     //update upsampled output directly in tensor buffer to avoid one
     //more memcpy
-    memcpy(input, net.input_i8, l.input_tensors[l.input_tensor].size);
+
+    /* If previous layer is not odla layer, do memcpy */
+    if (l.dla_params.from_odla_layer == -1)
+        memcpy(input, net.input_i8, l.input_tensors[l.input_tensor].size);
 
     if (l.num_input > 1) {
       for (int i = 0; i < l.num_input; i++) {

--- a/src/odla_layer.c
+++ b/src/odla_layer.c
@@ -88,16 +88,9 @@ odla_layer make_odla_layer(int batch, int h, int w, int c,
     l.num_input = odla_num_input(l.odla_runtime);
     l.input_tensors = calloc(l.num_input, sizeof(tensor));
     for (i = 0; i < l.num_input; i++) {
-        if (prev_odla_layer == NULL) {
-            l.input_tensors[i].w = odla_input_width(l.odla_runtime, i);
-            l.input_tensors[i].h = odla_input_height(l.odla_runtime, i);
-            l.input_tensors[i].c = odla_input_channel(l.odla_runtime, i);
-
-            l.input_tensors[i].size = odla_input_size(l.odla_runtime, i);
-            l.input_tensors[i].buffer = NULL;
-            odla_alloc_input_tensor(l.odla_runtime, &l.input_tensors[i].buffer, i, &l.input_tensors[i].hMem);
-        }
-        else {
+        /* If source of data to input tensor is from previous odla layer,
+            just bind the already allocated memory */
+        if (prev_odla_layer != NULL && i == l.input_tensor) {
             if (prev_odla_tensor != NULL) {
                 l.input_tensors[i] = *prev_odla_tensor;
                 odla_bind_input_tensor(l.odla_runtime, i, l.input_tensors[i].hMem);
@@ -106,6 +99,16 @@ odla_layer make_odla_layer(int batch, int h, int w, int c,
                 fprintf(stderr, "Invalid from_odla_tensor!\n");
             }
         }
+        else {
+            l.input_tensors[i].w = odla_input_width(l.odla_runtime, i);
+            l.input_tensors[i].h = odla_input_height(l.odla_runtime, i);
+            l.input_tensors[i].c = odla_input_channel(l.odla_runtime, i);
+
+            l.input_tensors[i].size = odla_input_size(l.odla_runtime, i);
+            l.input_tensors[i].buffer = NULL;
+            odla_alloc_input_tensor(l.odla_runtime, &l.input_tensors[i].buffer, i, &l.input_tensors[i].hMem);
+        }
+
     }
 
     //setup output tensors

--- a/src/odla_layer.h
+++ b/src/odla_layer.h
@@ -7,7 +7,7 @@
 typedef layer odla_layer;
 
 odla_layer make_odla_layer(int batch, int w, int h, int c,
-                            odla_params params);
+                            odla_params params, network *net);
 void forward_odla_layer(const layer l, network net);
 void backward_odla_layer(const layer l, network net);
 void resize_odla_layer(layer *l, int w, int h);

--- a/src/odla_layer_impl.cpp
+++ b/src/odla_layer_impl.cpp
@@ -60,7 +60,7 @@ extern "C" int odla_num_output(void *runtime)
     return num_output;
 }
 
-extern "C" void odla_alloc_input_tensor(void *runtime, void **buffer, int index)
+extern "C" void odla_alloc_input_tensor(void *runtime, void **buffer, int index, void **memory_handle)
 {
     void *hMem = NULL;
     int err = 0;
@@ -76,9 +76,11 @@ extern "C" void odla_alloc_input_tensor(void *runtime, void **buffer, int index)
     err = odla_runtime->bindInputTensor(index, hMem);
     if (err != true)
         fprintf(stderr, "bindInputTensor failed\n");
+
+    *memory_handle = hMem;
 }
 
-extern "C" void odla_alloc_output_tensor(void *runtime, void **buffer, int index)
+extern "C" void odla_alloc_output_tensor(void *runtime, void **buffer, int index, void **memory_handle)
 {
     void *hMem = NULL;
     int err = 0;
@@ -94,6 +96,18 @@ extern "C" void odla_alloc_output_tensor(void *runtime, void **buffer, int index
     err = odla_runtime->bindOutputTensor(index, hMem);
     if (err != true)
         fprintf(stderr, "bindOutputTensor failed\n");
+
+    *memory_handle = hMem;
+}
+
+extern "C" void odla_bind_input_tensor(void *runtime, int index, void *memory_handle)
+{
+    int err = 0;
+
+    IRuntime *odla_runtime = (IRuntime *)runtime;
+    err = odla_runtime->bindInputTensor(index, memory_handle);
+    if (err != true)
+        fprintf(stderr, "bindInputTensor failed\n");
 }
 
 extern "C" int odla_input_channel(void *runtime, int index)

--- a/src/parser.c
+++ b/src/parser.c
@@ -552,16 +552,23 @@ converter_layer parse_converter(list *options, size_params params)
     return layer;
 }
 
-odla_layer parse_odla(list *options, size_params params)
+odla_layer parse_odla(list *options, size_params params, network *net)
 {
     odla_params o_params = {0};
 
     o_params.instance = option_find_int(options, "instance", 0);
     o_params.loadable = option_find_str(options, "loadable", "");
     o_params.input_tensor = option_find_int(options, "input_tensor", 0);
+    o_params.from_odla_layer = option_find_int(options, "from_odla_layer", 0);
+    if (o_params.from_odla_layer != 0)
+        o_params.from_odla_layer += params.index;
+    else
+        o_params.from_odla_layer = -1;
+
+    o_params.from_odla_tensor = option_find_int(options, "from_odla_tensor", 0);
 
     odla_layer layer = make_odla_layer(params.batch, params.w, params.h,
-                                        params.c, o_params);
+                                        params.c, o_params, net);
     return layer;
 }
 
@@ -904,7 +911,7 @@ network *parse_network_cfg(char *filename)
         }else if(lt == CAFFE){
             l = parse_caffe(options, params);
         }else if(lt == ODLA){
-            l = parse_odla(options, params);
+            l = parse_odla(options, params, net);
         }else if(lt == SPLIT){
             l = parse_split(options, params, net);
         }else if(lt == ROUTE){


### PR DESCRIPTION
[1] Removes unnecessary split layer between two odla layers
[2] Prevent memcpy if previous layer is an odla layer.

Signed-off-by: arvind <am@nvidia.com>